### PR TITLE
fix: Fix main branch checkout in Docker workflow

### DIFF
--- a/.github/workflows/build_and_publish_docker.yml
+++ b/.github/workflows/build_and_publish_docker.yml
@@ -122,8 +122,8 @@ jobs:
       if: github.ref_type == 'tag' || (github.event_name == 'repository_dispatch' && github.event.client_payload.pr_number != '')
       run: |
         # Checkout main branch to avoid detached HEAD when pushing
+        git fetch origin main:main
         git checkout main
-        git pull origin main
         # Extract the primary image tag for updating README
         if [[ "${{ github.ref_type }}" == "tag" ]]; then
           # For tag releases, use the version tag


### PR DESCRIPTION
## Summary
Critical fix for the Docker workflow that was failing with:
```
error: pathspec 'main' did not match any file(s) known to git
```

## Problem
PR #9 was merged but still had the checkout error. When workflow runs on a tag (detached HEAD), it couldn't find the main branch.

## Solution
- Use `git fetch origin main:main` to ensure main branch exists locally
- Then checkout main normally
- This ensures README updates work correctly

## Test plan
- [ ] Next tag release should successfully update README without errors
- [ ] Docker image should be built and pushed correctly
- [ ] README in main branch should be updated with new version

🤖 Generated with Claude Code