### PR TITLE
fix: Add --set-upstream flag to git push in Docker workflow

### DIFF
--- a/.github/workflows/build_and_publish_docker.yml
+++ b/.github/workflows/build_and_publish_docker.yml
@@ -187,7 +187,7 @@ jobs:
           fi
           
           # Push changes back to the repository
-          git push
+          git push --set-upstream origin main
           
           echo "### 📝 Documentation Updated" >> $GITHUB_STEP_SUMMARY
           echo "README.md and user guides have been automatically updated with the new Docker image tag: \`$LATEST_TAG\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
Final fix for the Docker workflow README update automation.

## Problem
The v4.0.7 release almost worked perfectly but failed at the last step:
```
fatal: The current branch main has no upstream branch.
Error: Process completed with exit code 128.
```

## Solution
Add `--set-upstream` flag to the git push command to handle the case where main branch is fetched without tracking info.

## What worked in v4.0.7:
- ✅ Version bump (4.0.6 → 4.0.7)
- ✅ Tag creation
- ✅ Docker build triggered
- ✅ Docker image published as `ghcr.io/patrykiti/zen-mcp-server:v4.0.7`
- ✅ README was updated with new version
- ❌ Push failed (this PR fixes it)

## Test plan
After this fix, the next release should complete all steps successfully without errors.

🤖 Generated with Claude Code