### PR TITLE
docker: fix configuration examples for Claude Desktop

### DIFF
--- a/.github/workflows/build_and_publish_docker.yml
+++ b/.github/workflows/build_and_publish_docker.yml
@@ -98,13 +98,10 @@ jobs:
         echo "      \"command\": \"docker\"," >> $GITHUB_STEP_SUMMARY
         echo "      \"args\": [" >> $GITHUB_STEP_SUMMARY
         echo "        \"run\", \"--rm\", \"-i\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"-e\", \"GEMINI_API_KEY\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"-v\", \"\${HOME}:\${HOME}\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"GEMINI_API_KEY=<your_api_key_from_google_ai_studio>\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-v\", \"<path_to_your_workspace>:<path_to_your_workspace>\"," >> $GITHUB_STEP_SUMMARY
         echo "        \"$MAIN_TAG\"" >> $GITHUB_STEP_SUMMARY
-        echo "      ]," >> $GITHUB_STEP_SUMMARY
-        echo "      \"env\": {" >> $GITHUB_STEP_SUMMARY
-        echo "        \"GEMINI_API_KEY\": \"<your_api_key_from_google_ai_studio>\"" >> $GITHUB_STEP_SUMMARY
-        echo "      }" >> $GITHUB_STEP_SUMMARY
+        echo "      ]" >> $GITHUB_STEP_SUMMARY
         echo "    }" >> $GITHUB_STEP_SUMMARY
         echo "  }" >> $GITHUB_STEP_SUMMARY
         echo "}" >> $GITHUB_STEP_SUMMARY
@@ -119,31 +116,30 @@ jobs:
         echo "      \"command\": \"docker\"," >> $GITHUB_STEP_SUMMARY
         echo "      \"args\": [" >> $GITHUB_STEP_SUMMARY
         echo "        \"run\", \"--rm\", \"-i\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"-e\", \"GEMINI_API_KEY\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"-e\", \"OPENAI_API_KEY\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"-e\", \"XAI_API_KEY\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"-e\", \"OPENROUTER_API_KEY\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"-e\", \"CUSTOM_API_URL\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"-e\", \"CUSTOM_API_KEY\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"-e\", \"CUSTOM_MODEL_NAME\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"-e\", \"DEFAULT_MODEL\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"-v\", \"\${HOME}:\${HOME}\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"GEMINI_API_KEY=<your-gemini-key>\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"OPENAI_API_KEY=<your-openai-key>\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"XAI_API_KEY=<your-xai-key>\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"OPENROUTER_API_KEY=<your-openrouter-key>\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"CUSTOM_API_URL=http://host.docker.internal:11434/v1\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"CUSTOM_API_KEY=\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"CUSTOM_MODEL_NAME=llama3.2\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"DEFAULT_MODEL=auto\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-v\", \"<path_to_your_workspace>:<path_to_your_workspace>\"," >> $GITHUB_STEP_SUMMARY
         echo "        \"$MAIN_TAG\"" >> $GITHUB_STEP_SUMMARY
-        echo "      ]," >> $GITHUB_STEP_SUMMARY
-        echo "      \"env\": {" >> $GITHUB_STEP_SUMMARY
-        echo "        \"GEMINI_API_KEY\": \"<your-gemini-key>\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"OPENAI_API_KEY\": \"<your-openai-key>\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"XAI_API_KEY\": \"<your-xai-key>\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"OPENROUTER_API_KEY\": \"<your-openrouter-key>\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"CUSTOM_API_URL\": \"http://host.docker.internal:11434/v1\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"CUSTOM_API_KEY\": \"\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"CUSTOM_MODEL_NAME\": \"llama3.2\"," >> $GITHUB_STEP_SUMMARY
-        echo "        \"DEFAULT_MODEL\": \"auto\"" >> $GITHUB_STEP_SUMMARY
-        echo "      }" >> $GITHUB_STEP_SUMMARY
+        echo "      ]" >> $GITHUB_STEP_SUMMARY
         echo "    }" >> $GITHUB_STEP_SUMMARY
         echo "  }" >> $GITHUB_STEP_SUMMARY
         echo "}" >> $GITHUB_STEP_SUMMARY
         echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        
+        echo "**Note:** Replace \`<path_to_your_workspace>\` with the directory where your projects are located." >> $GITHUB_STEP_SUMMARY
+        echo "This is the directory that MCP server will have access to. Examples:" >> $GITHUB_STEP_SUMMARY
+        echo "- macOS: \`/Users/your_username/Documents\` or \`/Users/your_username/Projects\`" >> $GITHUB_STEP_SUMMARY
+        echo "- Linux: \`/home/your_username/projects\` or \`/home/your_username/workspace\`" >> $GITHUB_STEP_SUMMARY
+        echo "- Windows: \`C:/Users/your_username/Documents\` or \`C:/Projects\`" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "⚠️ **Important:** The path must be the same on both sides of the colon!" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
         echo "### 🐳 Using Docker Compose" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build_and_publish_docker.yml
+++ b/.github/workflows/build_and_publish_docker.yml
@@ -124,6 +124,17 @@ jobs:
         echo "        \"-e\", \"CUSTOM_API_KEY=\"," >> $GITHUB_STEP_SUMMARY
         echo "        \"-e\", \"CUSTOM_MODEL_NAME=llama3.2\"," >> $GITHUB_STEP_SUMMARY
         echo "        \"-e\", \"DEFAULT_MODEL=auto\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"OPENAI_ALLOWED_MODELS=o3-mini,o4-mini\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"GOOGLE_ALLOWED_MODELS=flash,pro\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"XAI_ALLOWED_MODELS=grok,grok-3-fast\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"OPENROUTER_ALLOWED_MODELS=opus,sonnet,mistral\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"OPENROUTER_REFERER=https://your-app.com\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"OPENROUTER_TITLE=Your App Name\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"CUSTOM_MODELS_CONFIG_PATH=/path/to/custom_models.json\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"DEFAULT_THINKING_MODE_THINKDEEP=high\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"CONVERSATION_TIMEOUT_HOURS=5\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"MAX_CONVERSATION_TURNS=20\"," >> $GITHUB_STEP_SUMMARY
+        echo "        \"-e\", \"LOG_LEVEL=INFO\"," >> $GITHUB_STEP_SUMMARY
         echo "        \"-v\", \"<path_to_your_workspace>:<path_to_your_workspace>\"," >> $GITHUB_STEP_SUMMARY
         echo "        \"$MAIN_TAG\"" >> $GITHUB_STEP_SUMMARY
         echo "      ]" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -207,7 +207,7 @@ jobs:
             - `ghcr.io/patrykiti/zen-mcp-server:v5.2.4` - Specific version
 
             For more details, see the [Docker setup guide](docker-compose.yml) in this repository.
-            DOCKER_SECTION
+DOCKER_SECTION
             echo "Docker section appended to README.md"
             echo "::endgroup::"
             git add README.md

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -160,6 +160,17 @@ jobs:
                     "-e", "CUSTOM_API_KEY=",
                     "-e", "CUSTOM_MODEL_NAME=llama3.2",
                     "-e", "DEFAULT_MODEL=auto",
+                    "-e", "OPENAI_ALLOWED_MODELS=o3-mini,o4-mini",
+                    "-e", "GOOGLE_ALLOWED_MODELS=flash,pro",
+                    "-e", "XAI_ALLOWED_MODELS=grok,grok-3-fast",
+                    "-e", "OPENROUTER_ALLOWED_MODELS=opus,sonnet,mistral",
+                    "-e", "OPENROUTER_REFERER=https://your-app.com",
+                    "-e", "OPENROUTER_TITLE=Your App Name",
+                    "-e", "CUSTOM_MODELS_CONFIG_PATH=/path/to/custom_models.json",
+                    "-e", "DEFAULT_THINKING_MODE_THINKDEEP=high",
+                    "-e", "CONVERSATION_TIMEOUT_HOURS=5",
+                    "-e", "MAX_CONVERSATION_TURNS=20",
+                    "-e", "LOG_LEVEL=INFO",
                     "-v", "<path_to_your_workspace>:<path_to_your_workspace>",
                     "ghcr.io/patrykiti/zen-mcp-server:latest"
                   ]

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -135,13 +135,10 @@ jobs:
                   "command": "docker",
                   "args": [
                     "run", "--rm", "-i",
-                    "-e", "GEMINI_API_KEY",
-                    "-v", "${HOME}:${HOME}",
+                    "-e", "GEMINI_API_KEY=<your_api_key_from_google_ai_studio>",
+                    "-v", "<path_to_your_workspace>:<path_to_your_workspace>",
                     "ghcr.io/patrykiti/zen-mcp-server:latest"
-                  ],
-                  "env": {
-                    "GEMINI_API_KEY": "<your_api_key_from_google_api_studio>"
-                  }
+                  ]
                 }
               }
             }
@@ -155,31 +152,29 @@ jobs:
                   "command": "docker",
                   "args": [
                     "run", "--rm", "-i",
-                    "-e", "GEMINI_API_KEY",
-                    "-e", "OPENAI_API_KEY",
-                    "-e", "XAI_API_KEY",
-                    "-e", "OPENROUTER_API_KEY",
-                    "-e", "CUSTOM_API_URL",
-                    "-e", "CUSTOM_API_KEY",
-                    "-e", "CUSTOM_MODEL_NAME",
-                    "-e", "DEFAULT_MODEL",
-                    "-v", "${HOME}:${HOME}",
+                    "-e", "GEMINI_API_KEY=<your-gemini-key>",
+                    "-e", "OPENAI_API_KEY=<your-openai-key>",
+                    "-e", "XAI_API_KEY=<your-xai-key>",
+                    "-e", "OPENROUTER_API_KEY=<your-openrouter-key>",
+                    "-e", "CUSTOM_API_URL=http://host.docker.internal:11434/v1",
+                    "-e", "CUSTOM_API_KEY=",
+                    "-e", "CUSTOM_MODEL_NAME=llama3.2",
+                    "-e", "DEFAULT_MODEL=auto",
+                    "-v", "<path_to_your_workspace>:<path_to_your_workspace>",
                     "ghcr.io/patrykiti/zen-mcp-server:latest"
-                  ],
-                  "env": {
-                    "GEMINI_API_KEY": "<your-gemini-key>",
-                    "OPENAI_API_KEY": "<your-openai-key>",
-                    "XAI_API_KEY": "<your-xai-key>",
-                    "OPENROUTER_API_KEY": "<your-openrouter-key>",
-                    "CUSTOM_API_URL": "http://host.docker.internal:11434/v1",
-                    "CUSTOM_API_KEY": "",
-                    "CUSTOM_MODEL_NAME": "llama3.2",
-                    "DEFAULT_MODEL": "auto"
-                  }
+                  ]
                 }
               }
             }
             ```
+
+            **Note:** Replace `<path_to_your_workspace>` with the directory where your projects are located.
+            This is the directory that MCP server will have access to. Examples:
+            - macOS: `/Users/your_username/Documents` or `/Users/your_username/Projects`
+            - Linux: `/home/your_username/projects` or `/home/your_username/workspace`
+            - Windows: `C:/Users/your_username/Documents` or `C:/Projects`
+            
+            ⚠️ **Important:** The path must be the same on both sides of the colon!
 
             ### Using Docker Compose
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,14 @@ services:
       - OPENAI_ALLOWED_MODELS=${OPENAI_ALLOWED_MODELS:-}
       - GOOGLE_ALLOWED_MODELS=${GOOGLE_ALLOWED_MODELS:-}
       - XAI_ALLOWED_MODELS=${XAI_ALLOWED_MODELS:-}
+      - OPENROUTER_ALLOWED_MODELS=${OPENROUTER_ALLOWED_MODELS:-}
+      
+      # OpenRouter custom headers
+      - OPENROUTER_REFERER=${OPENROUTER_REFERER:-}
+      - OPENROUTER_TITLE=${OPENROUTER_TITLE:-}
+      
+      # Custom models configuration path
+      - CUSTOM_MODELS_CONFIG_PATH=${CUSTOM_MODELS_CONFIG_PATH:-}
       
       # Workspace configuration
       - WORKSPACE_ROOT=${WORKSPACE_ROOT:-${HOME}}


### PR DESCRIPTION
## Summary
This PR fixes the Docker configuration examples in workflows to use a format that actually works in Claude Desktop.

## Problem
The previous configuration with separate `args` and `env` sections was causing "failed" status in Claude Desktop, even though the command worked when run manually.

## Solution
Updated configuration to use inline environment variables and explicit workspace paths.

### Changes Made

1. **Environment Variables** - Changed from:
   ```json
   "args": ["-e", "GEMINI_API_KEY"],
   "env": { "GEMINI_API_KEY": "value" }
   ```
   To:
   ```json
   "args": ["-e", "GEMINI_API_KEY=value"]
   ```

2. **Path Mounting** - Changed from:
   ```json
   "-v", "${HOME}:${HOME}"
   ```
   To:
   ```json
   "-v", "<path_to_your_workspace>:<path_to_your_workspace>"
   ```

3. **Added Clear Instructions** - Added detailed explanation about:
   - What workspace path means (directory where projects are located)
   - Examples for different operating systems
   - Important note that paths must be identical on both sides of colon

## Files Updated
- `.github/workflows/sync-upstream.yml` - Updated Docker configuration examples
- `.github/workflows/build_and_publish_docker.yml` - Updated Docker configuration examples

## Testing
✅ Tested configuration in Claude Desktop - works correctly
✅ No more "failed" status when using the updated format
✅ MCP server can access files in the specified workspace directory